### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-django-unittest.yml
+++ b/.github/workflows/python-django-unittest.yml
@@ -9,6 +9,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest  


### PR DESCRIPTION
Potential fix for [https://github.com/kollinslima/WiseWallet/security/code-scanning/1](https://github.com/kollinslima/WiseWallet/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs tests, it does not need write access to repository contents or other resources. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/python-django-unittest.yml` above the `jobs:` key, after the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
